### PR TITLE
test: implement test that check creation of 404 box in not found page

### DIFF
--- a/src/features/notFound/NotFoundPage.test.tsx
+++ b/src/features/notFound/NotFoundPage.test.tsx
@@ -1,0 +1,32 @@
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import NotFoundPage from './NotFoundPage';
+import { NotFoundConstants } from './constants';
+
+describe('NotFoundPage', () => {
+  it('Must render NotFound page with OopsBox inside and anchor with link to main page', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    );
+
+    const oopsTitle: HTMLHeadingElement = screen.getByRole('heading', {
+      name: NotFoundConstants.errorText,
+    });
+    expect(oopsTitle).toBeInTheDocument();
+
+    const mainMessage: HTMLHeadingElement = screen.getByRole('heading', {
+      name: NotFoundConstants.mainMessage,
+    });
+    expect(mainMessage).toBeInTheDocument();
+
+    const link: HTMLAnchorElement = screen.getByRole('link', {
+      name: NotFoundConstants.linkLabel,
+    });
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute('href')).toBe('/');
+  });
+});

--- a/src/features/notFound/components/OopsBox.test.tsx
+++ b/src/features/notFound/components/OopsBox.test.tsx
@@ -5,7 +5,7 @@ import OopsBox from './OopsBox';
 import { NotFoundConstants } from '../constants';
 
 describe('OopsBox', () => {
-  it('Must render ', () => {
+  it('Must render Oops box with text error end code of error.', () => {
     render(<OopsBox />);
 
     expect(screen.getByRole('heading', { name: NotFoundConstants.errorText })).toBeInTheDocument();

--- a/src/features/notFound/components/OopsBox.test.tsx
+++ b/src/features/notFound/components/OopsBox.test.tsx
@@ -1,0 +1,14 @@
+import '@testing-library/jest-dom';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import OopsBox from './OopsBox';
+import { NotFoundConstants } from '../constants';
+
+describe('OopsBox', () => {
+  it('Must render ', () => {
+    render(<OopsBox />);
+
+    expect(screen.getByRole('heading', { name: NotFoundConstants.errorText })).toBeInTheDocument();
+    expect(screen.getByAltText(NotFoundConstants.errorText)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Type of PR (check all applicable)

- [ ] 🚀 Feature
- [ ] 🧹 Refactor
- [ ] 🪲 Bug Fix
- [X] 📝 Tests
- [ ] 📖 Docs update
- [ ] 🛠️ Chore

## Description
Implement tests that cover OopsBox and NotFoundPage components, that should view 404 box and link to main page.
## Rationale
Ensuring the reliability and robustness of the implemented features && criteria of mentor check .

## Related Tasks & Issues

- Closes task #77

## Screenshot (optional)

**BEFORE**:
<img width="937" alt="Screenshot 2025-05-19 at 03 54 35" src="https://github.com/user-attachments/assets/f1827986-688d-49e8-b7fe-ac5c1d1ee2a1" />