### PR TITLE
feat/40_billing-address

### DIFF
--- a/src/features/registration/components/RegistrationForm/constants.ts
+++ b/src/features/registration/components/RegistrationForm/constants.ts
@@ -34,4 +34,22 @@ export const fieldsConfig: FieldSection[] = [
       { id: 'postalCode', label: 'Postal code' },
     ],
   },
+  {
+    section: 'Billing Address',
+    fields: [
+      { id: 'streetBill', label: 'Street' },
+      { id: 'cityBill', label: 'City' },
+      {
+        id: 'countryBill',
+        label: 'Country',
+        type: 'select',
+        options: [
+          { value: 'GB', label: 'United Kingdom' },
+          { value: 'DE', label: 'Germany' },
+          { value: 'IE', label: 'Ireland' },
+        ],
+      },
+      { id: 'postalCodeBill', label: 'Postal code' },
+    ],
+  },
 ];

--- a/src/utils/validationSchema.ts
+++ b/src/utils/validationSchema.ts
@@ -27,13 +27,39 @@ const passwordSchema = yup
   .matches(/[a-z]/, 'Must include at least one lowercase Latin letter')
   .matches(/\d/, 'Must include at least one number');
 
+// TODO ??? I don't know: how we can use addressSchema in validations registrationSchema
+// const addressSchema = yup.object({
+//   street: yup
+//     .string()
+//     .required('Street is required')
+//     .matches(/^[\d './A-Z[^a-z-]+$/, {
+//       message: "Only Latin letters, numbers, dots, ', - and spaces allowed",
+//     }),
+//   city: yup
+//     .string()
+//     .required('City is required')
+//     .matches(/^[A-Za-z]+(?:[ -][A-Za-z]+)*$/, {
+//       message: 'Only Latin letters, single spaces and hyphens allowed',
+//     }),
+//   country: yup.string().required('Country is required'),
+//   postalCode: yup
+//     .string()
+//     .required('Postal code is required')
+//     .test('is-valid-postal-code', 'Invalid postal code format', function (value) {
+//       const { country } = this.parent;
+//       const regex = postalCodeRegexMap[country];
+//       if (!regex) return true;
+//       return regex.test(value || '');
+//     }),
+// });
+
 const postalCodeRegexMap: Record<string, RegExp> = {
   GB: /^[A-Z]{1,2}\d{1,2}[A-Z]?\s*\d[A-Z]{2}$/,
   DE: /^\d{5}$/,
   IE: /^[A-Z]\d{2}\s?[\dA-Z]{4}$/,
 };
 
-export const registrationSchema = yup.object({
+export const registrationSchema = yup.object().shape({
   email: emailSchema,
   password: passwordSchema,
   firstName: yup
@@ -77,6 +103,46 @@ export const registrationSchema = yup.object({
       if (!regex) return true;
       return regex.test(value || '');
     }),
+
+  isBilling: yup.boolean().required(),
+
+  streetBill: yup.string().when('isBilling', ([isBilling], schema) => {
+    if (isBilling === false) {
+      return schema.required('Street is required').matches(/^[\d './A-Z[^a-z-]+$/, {
+        message: "Only Latin letters, numbers, dots, ', - and spaces allowed",
+      });
+    }
+    return schema.notRequired();
+  }),
+  cityBill: yup.string().when('isBilling', ([isBilling], schema) => {
+    if (isBilling === false) {
+      return schema.required('City is required').matches(/^[A-Za-z]+(?:[ -][A-Za-z]+)*$/, {
+        message: 'Only Latin letters, single spaces and hyphens allowed',
+      });
+    }
+    return schema.notRequired();
+  }),
+
+  countryBill: yup.string().when('isBilling', ([isBilling], schema) => {
+    if (isBilling === false) {
+      return schema.required('Country is required');
+    }
+    return schema.notRequired();
+  }),
+
+  postalCodeBill: yup.string().when('isBilling', ([isBilling], schema) => {
+    if (isBilling === false) {
+      return schema
+        .required('Postal code is required')
+        .test('is-valid-postal-code-bill', 'Invalid postal code format', function (value) {
+          const { countryBill } = this.parent;
+          const regex = postalCodeRegexMap[countryBill];
+          if (!regex) return true;
+          return regex.test(value || '');
+        });
+    }
+    return schema.notRequired();
+  }),
 });
 
 export const loginSchema = yup.object({


### PR DESCRIPTION
## Type of PR (check all applicable)

- [X] 🚀 Feature
- [ ] 🧹 Refactor
- [ ] 🪲 Bug Fix
- [ ] 📝 Tests
- [ ] 📖 Docs update
- [ ] 🛠️ Chore

## Description
- Users can enter separate addresses for billing and shipping during the registration process. 

- Users can choose to use the same address for both billing and shipping. 

- The chosen addresses are saved in the user profile upon successful registration. 

- Proper integration with the commercetools API for storing billing and shipping address information.

## Rationale
Users can provide different addresses for billing and shipping.

## Related Tasks & Issues

- Closes task #40 

## Screenshot (optional). 

<img width="738" alt="Screenshot 2025-05-19 at 7 28 46 pm" src="https://github.com/user-attachments/assets/94bdf209-88ee-41f1-8690-123ec59dee71" />

<img width="481" alt="Screenshot 2025-05-19 at 7 28 18 pm" src="https://github.com/user-attachments/assets/98953b49-5787-4e8d-bf82-2c934f6abafe" />

