### PR TITLE
 feat/106_header-profile-link

### DIFF
--- a/src/api/authApi.ts
+++ b/src/api/authApi.ts
@@ -1,5 +1,5 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-import type { LoginResponse, RegistrationDataApi } from '../types/auth';
+import type { Customer, LoginResponse, RegistrationDataApi } from '../types/auth';
 import { apiUrl, clientId, clientSecret, projectKey, ResponseCodes } from './constants';
 import { getClientToken } from '../services/serviceToken';
 
@@ -42,7 +42,7 @@ export const authApi = createApi({
       },
     }),
 
-    getMe: builder.query<{ email: string }, string>({
+    getMe: builder.query<Customer, string>({
       queryFn: async (accessToken) => {
         const result = await fetch(`${apiUrl}/${projectKey}/me`, {
           headers: {

--- a/src/components/UserAvatar/UserAvatar.module.scss
+++ b/src/components/UserAvatar/UserAvatar.module.scss
@@ -1,0 +1,5 @@
+.user-avatar {
+  cursor: pointer;
+  font-weight: bold;
+  transition: all 0.4s ease-in-out;
+}

--- a/src/components/UserAvatar/UserAvatar.tsx
+++ b/src/components/UserAvatar/UserAvatar.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { Avatar } from '@mui/material';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../store/store';
+import { useLazyGetMeQuery } from '../../api/authApi';
+import { getUserInitials } from '../../utils/getUserInitials';
+import classes from './UserAvatar.module.scss';
+
+export const UserAvatar = () => {
+  const accessToken = useSelector((state: RootState) => state.auth.accessToken);
+  const [trigger, { data: user }] = useLazyGetMeQuery();
+
+  useEffect(() => {
+    if (accessToken) {
+      trigger(accessToken);
+    }
+  }, [accessToken, trigger]);
+
+  if (!user) return null;
+
+  return (
+    <Avatar
+      className={classes['user-avatar']}
+      sx={{
+        width: 62,
+        height: 62,
+        bgcolor: 'background.default',
+        color: 'text.primary',
+        '&:hover': {
+          filter: 'brightness(90%)',
+          color: 'text.secondary',
+        },
+      }}
+    >
+      {getUserInitials(user.firstName, user.lastName)}
+    </Avatar>
+  );
+};

--- a/src/layouts/components/Header/Header.tsx
+++ b/src/layouts/components/Header/Header.tsx
@@ -23,11 +23,12 @@ import { logout } from '../../../store/slices/authSlice';
 import { useSnackbar } from 'notistack';
 import { useAuth } from '../../../hooks/useAuth';
 import { theme } from '../../../theme';
+import { UserAvatar } from '../../../components/UserAvatar/UserAvatar';
+import { Tooltip } from '@mui/material';
 
 export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { isAuthenticated, isInitialized } = useSelector((state: RootState) => state.auth);
-  const userEmail = useSelector((state: RootState) => state.auth.email);
   const dispatch = useDispatch();
   const { enqueueSnackbar } = useSnackbar();
   const navigate = useNavigate();
@@ -64,14 +65,9 @@ export default function Header() {
           {isAuthenticated && (
             <>
               <ListItem disablePadding>
-                <ListItemText
-                  sx={{ textAlign: 'center', padding: '8px' }}
-                  slotProps={{
-                    primary: { className: classes['user-info'] },
-                  }}
-                >
-                  {userEmail}
-                </ListItemText>
+                <ListItemButton component={NavLink} to={Paths.PROFILE} sx={{ textAlign: 'center' }}>
+                  <ListItemText>User Profile</ListItemText>
+                </ListItemButton>
               </ListItem>
               <ListItem disablePadding>
                 <ListItemButton onClick={handleLogout} sx={{ textAlign: 'center' }}>
@@ -188,16 +184,11 @@ export default function Header() {
               <Stack direction="row" spacing={4}>
                 {isAuthenticated ? (
                   <>
-                    <Typography
-                      sx={{
-                        color: 'secondary.contrastText',
-                        alignSelf: 'center',
-                        marginRight: 2,
-                      }}
-                      className={classes['user-info']}
-                    >
-                      {userEmail}
-                    </Typography>
+                    <Tooltip title="User Profile" arrow>
+                      <Link component={NavLink} to={Paths.PROFILE}>
+                        <UserAvatar />
+                      </Link>
+                    </Tooltip>
                     <Button
                       onClick={handleLogout}
                       variant="outlined"

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -17,3 +17,9 @@ export type LoginResponse = {
   scope: string;
   refresh_token?: string;
 };
+
+export type Customer = {
+  email: string;
+  firstName: string;
+  lastName: string;
+};

--- a/src/utils/getUserInitials.ts
+++ b/src/utils/getUserInitials.ts
@@ -1,0 +1,5 @@
+export const getUserInitials = (firstName?: string, lastName?: string): string => {
+  const first = firstName?.[0] ?? '';
+  const last = lastName?.[0] ?? '';
+  return (first + last).toUpperCase();
+};


### PR DESCRIPTION
## Type of PR (check all applicable)

- [X] 🚀 Feature
- [ ] 🧹 Refactor
- [ ] 🪲 Bug Fix
- [ ] 📝 Tests
- [ ] 📖 Docs update
- [ ] 🛠️ Chore

## Description
Add 'User Avatar'-link to Header

## Rationale
To provide users with easy access to their Profile page

## Related Tasks & Issues

- Closes task #106 

## Screenshot (optional)

**AFTER**:
<img width="364" alt="Screenshot 2025-05-27 at 11 02 33 pm" src="https://github.com/user-attachments/assets/f4034a2d-3cb4-4078-898b-7de289654b2d" />

<img width="246" alt="Screenshot 2025-05-27 at 11 02 48 pm" src="https://github.com/user-attachments/assets/b6eba9ae-a68d-4320-bb44-1eb59ac60b33" />
