### PR TITLE
feat/174_total-cost

### DIFF
--- a/src/features/cart/CartPage.tsx
+++ b/src/features/cart/CartPage.tsx
@@ -6,6 +6,7 @@ import { Link as RouterLink } from 'react-router';
 import { Paths } from '../../types/paths';
 import { useGetMyActiveCartQuery } from '../../api/cartApi';
 import CartItem from './components/CartItem/CartItem';
+import { CartSummary } from './components/CartSummary/CartSummary';
 
 export default function CartPage() {
   const { data: cart, isLoading } = useGetMyActiveCartQuery();
@@ -88,8 +89,7 @@ export default function CartPage() {
 
         <Grid size={{ xs: 12, md: 4 }} className={styles.summary}>
           <Title title="Order Summary" variant="h3" />
-          {/* TODO Total cart info */}
-          {/* <CartSummary cart={cart} /> */}
+          <CartSummary cart={cart} />
         </Grid>
       </Grid>
     </Box>

--- a/src/features/cart/components/CartSummary/CartSummary.tsx
+++ b/src/features/cart/components/CartSummary/CartSummary.tsx
@@ -1,0 +1,38 @@
+import { Box, Button, Typography } from '@mui/material';
+import { formatPrice } from '../../../../utils/formatPrice/formatPrice';
+import type { Cart } from '../../../../types/cartApi';
+import { useSnackbar } from 'notistack';
+
+export function CartSummary({ cart }: { cart: Cart }) {
+  const { enqueueSnackbar } = useSnackbar();
+  const totalItems = cart.lineItems.reduce((total, item) => total + item.quantity, 0);
+  const totalCost = cart.totalPrice;
+
+  const handleCheckout = () => {
+    enqueueSnackbar('The shelter animals are grateful!', {
+      variant: 'success',
+      anchorOrigin: {
+        vertical: 'bottom',
+        horizontal: 'center',
+      },
+      autoHideDuration: 3000,
+    });
+  };
+
+  return (
+    <>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', my: 2 }}>
+        <Typography variant="h6">
+          {totalItems} sticker{totalItems === 1 ? '' : 's'}
+        </Typography>
+        <Typography variant="h6" color="primary">
+          {formatPrice(totalCost)} €
+        </Typography>
+      </Box>
+
+      <Button variant="contained" fullWidth onClick={handleCheckout}>
+        Checkout
+      </Button>
+    </>
+  );
+}


### PR DESCRIPTION
## Type of PR (check all applicable)

- [X] 🚀 Feature
- [ ] 🧹 Refactor
- [ ] 🪲 Bug Fix
- [ ] 📝 Tests
- [ ] 📖 Docs update
- [ ] 🛠️ Chore

## Description
Recalculate Total Cost Upon Cart Updates

## Rationale
To ensure that users always have accurate information about their purchases

## Related Tasks & Issues

- Closes task #174 

## Screenshot (optional)
**AFTER**:

<img width="920" alt="Screenshot 2025-06-15 at 2 39 36 pm" src="https://github.com/user-attachments/assets/6b5c4e56-a431-474e-8efe-b653da7c4c30" />
